### PR TITLE
Modifications for VNDK

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -18,7 +18,6 @@ include $(CLEAR_VARS)
 
 #include external/stlport/libstlport.mk
 LOCAL_C_INCLUDES += $(LOCAL_PATH) \
-                    external/thermal_daemon/src \
                     external/libxml2/include \
                     external/icu/icu4c/source/common \
                     system/core/include/ \
@@ -26,7 +25,9 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH) \
                     system/native/include
 
 LOCAL_MODULE := power.$(TARGET_BOARD_PLATFORM)
+LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_RELATIVE_PATH := hw
+LOCAL_HEADER_LIBRARIES += libhardware_headers
 
 # main libpower source
 LOCAL_SRC_FILES := power.cpp
@@ -36,7 +37,7 @@ LOCAL_SRC_FILES += DevicePowerMonitor.cpp \
                    DevicePowerMonitorInfo.cpp \
                    CGroupCpusetController.cpp
 
-LOCAL_SHARED_LIBRARIES := liblog libcutils libutils libdl libicuuc libicui18n libbinder
+LOCAL_SHARED_LIBRARIES := liblog libcutils libutils libdl libbinder
 
 LOCAL_MODULE_TAGS := optional
 
@@ -49,8 +50,6 @@ ifneq ($(TARGET_BUILD_VARIANT),user)
 endif
 
 LOCAL_MODULE_OWNER := intel
-
-LOCAL_INIT_RC := powerhal.rc
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/CGroupCpusetController.cpp
+++ b/CGroupCpusetController.cpp
@@ -32,8 +32,8 @@
 
 static const char* CPUSET_ROOT_CPUS = "/dev/cpuset/cpus";
 static const char* CPUSET_NON_INTERACTIVE_CPUS = "/dev/cpuset/non_interactive/cpus";
-static const char* POWER_HAL_CPUSET_PROPERTY = "ro.powerhal.cpuset_config";
-static const char* POWER_HAL_CPUSET_PROPERTY_DEBUG = "persist.powerhal.cpuset_config"; /* for userdebug, eng build tuning*/
+static const char* POWER_HAL_CPUSET_PROPERTY = "ro.vendor.powerhal.cpuset_config";
+static const char* POWER_HAL_CPUSET_PROPERTY_DEBUG = "persist.vendor.powerhal.cpuset_config"; /* for userdebug, eng build tuning*/
 
 CGroupCpusetController::CGroupCpusetController()
 {

--- a/helper/power_hal_helper.c
+++ b/helper/power_hal_helper.c
@@ -28,8 +28,9 @@
 #include <cutils/log.h>
 #include <cutils/properties.h>
 #include <errno.h>
+#include <unistd.h>
 
-static const char* PROPERTY_NON_INTERACTIVE_PROC = "sys.power_hal.niproc";
+static const char* PROPERTY_NON_INTERACTIVE_PROC = "vendor.power_hal.niproc";
 
 #define PROCESS_NAME_LEN 32
 

--- a/powerhal.rc
+++ b/powerhal.rc
@@ -1,9 +1,0 @@
-on post-fs
-    mkdir /dev/cpuset/non_interactive
-    write /dev/cpuset/non_interactive/mems 0
-    write /dev/cpuset/non_interactive/cpus 0-3
-    chown system system /dev/cpuset/non_interactive
-    chown system system /dev/cpuset/non_interactive/cpus
-
-    setprop ro.powerhal.cpuset_config """"
-


### PR DESCRIPTION
The patch does the following:
1) Adds vendor namespace to power properties
2) Installs the power.celadon modules to vendor partition
3) Removes the unused libicuuc.so libicui18n.so libraries

Tracked-On: https://jira.devtools.intel.com/browse/OAM-75180
Signed-off-by: Abhilash Kesavan <abhilash.kesavan@intel.com>
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>