### PR TITLE
Power: fix kw issue

### DIFF
--- a/power.cpp
+++ b/power.cpp
@@ -142,7 +142,7 @@ static void get_pstate_boost_pct(char* old_min_perf_pct)
     unsigned int turbo_pct = atoi(turbo_pct_sysfs);
     int pstate_ival = (scaling_max_freq - scaling_min_freq) / (num_pstates - 1);
     unsigned int hfm = scaling_max_freq - (pstate_ival * ((turbo_pct * num_pstates)/100));
-    int min_perf_pct;
+    int min_perf_pct = 0;
     if (scaling_min_freq > 0)
         min_perf_pct = (hfm * atoi(old_min_perf_pct)) / scaling_min_freq;
     snprintf(new_min_perf_pct, sizeof(new_min_perf_pct), "%d", min_perf_pct);


### PR DESCRIPTION
'min_perf_pct' might be used uninitialized in get_pstate_boost_pct()

Tracked-On: OAM-83513
Signed-off-by: Chen, Hu <hu1.chen@intel.com>